### PR TITLE
Add commit message guidelines

### DIFF
--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -1,0 +1,8 @@
+# Commit Message Guidelines
+
+Use concise summaries to clarify the intent of every change.
+
+Example:
+```
+Sanitize trigger/modifier names and update references
+```


### PR DESCRIPTION
## Summary
- outline commit message style in `docs/commit-guidelines.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f55f9ed248323ac146dd26d4fb699