### PR TITLE
Fix missing building effect blocks

### DIFF
--- a/Original automagic - working - not updated/3071418704/common/scripted_effects/build_scripted_effect.txt
+++ b/Original automagic - working - not updated/3071418704/common/scripted_effects/build_scripted_effect.txt
@@ -4190,89 +4190,124 @@ prev = {remove_short_term_gold = normal_building_tier_8_cost}
 }
 }
 
-  # Tribal Buildings
-
-building_requirement_tribal = yes
-}
-add_building = longhouses_01
-prev = {remove_short_term_gold = tribal_building_tier_1_cost}
-}
-if = {
-limit = {
-prev = {gold > tribal_building_tier_2_cost}
-has_building = longhouses_01
-building_requirement_tribal = yes
-OR = {
-mpo_permafrost_building_trigger = yes
-prev.culture = {has_innovation = innovation_barracks}
-}
-}
-add_building = longhouses_02
-prev = {remove_short_term_gold = tribal_building_tier_2_cost}
-}
-}
-
-
-building_requirement_tribal = yes
-}
-add_building = war_camps_01
-prev = {remove_short_term_gold = tribal_building_tier_1_cost}
-}
-if = {
-limit = {
-prev = {gold > tribal_building_tier_2_cost}
-has_building = war_camps_01
-building_requirement_tribal = yes
-OR = {
-mpo_permafrost_building_trigger = yes
-prev.culture = {has_innovation = innovation_barracks}
-}
-}
-add_building = war_camps_02
-prev = {remove_short_term_gold = tribal_building_tier_2_cost}
-}
+# Tribal Buildings
+add_longhouses_building_effect = {
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_1_cost}
+            has_free_building_slot = yes
+            NOT = {
+                has_building = longhouses_01
+                has_building = longhouses_02
+            }
+            building_requirement_tribal = yes
+        }
+        add_building = longhouses_01
+        prev = {remove_short_term_gold = tribal_building_tier_1_cost}
+    }
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_2_cost}
+            has_building = longhouses_01
+            building_requirement_tribal = yes
+            OR = {
+                mpo_permafrost_building_trigger = yes
+                prev.culture = {has_innovation = innovation_barracks}
+            }
+        }
+        add_building = longhouses_02
+        prev = {remove_short_term_gold = tribal_building_tier_2_cost}
+    }
 }
 
 
-building_requirement_tribal = yes
-}
-add_building = palisades_01
-prev = {remove_short_term_gold = tribal_building_tier_1_cost}
-}
-if = {
-limit = {
-prev = {gold > tribal_building_tier_2_cost}
-has_building = palisades_01
-building_requirement_tribal = yes
-OR = {
-mpo_permafrost_building_trigger = yes
-prev.culture = {has_innovation = innovation_barracks}
-}
-}
-add_building = palisades_02
-prev = {remove_short_term_gold = tribal_building_tier_2_cost}
-}
+add_war_camps_building_effect = {
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_1_cost}
+            has_free_building_slot = yes
+            NOT = {
+                has_building = war_camps_01
+                has_building = war_camps_02
+            }
+            building_requirement_tribal = yes
+        }
+        add_building = war_camps_01
+        prev = {remove_short_term_gold = tribal_building_tier_1_cost}
+    }
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_2_cost}
+            has_building = war_camps_01
+            building_requirement_tribal = yes
+            OR = {
+                mpo_permafrost_building_trigger = yes
+                prev.culture = {has_innovation = innovation_barracks}
+            }
+        }
+        add_building = war_camps_02
+        prev = {remove_short_term_gold = tribal_building_tier_2_cost}
+    }
 }
 
 
-building_requirement_tribal = yes
+add_palisades_building_effect = {
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_1_cost}
+            has_free_building_slot = yes
+            NOT = {
+                has_building = palisades_01
+                has_building = palisades_02
+            }
+            building_requirement_tribal = yes
+        }
+        add_building = palisades_01
+        prev = {remove_short_term_gold = tribal_building_tier_1_cost}
+    }
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_2_cost}
+            has_building = palisades_01
+            building_requirement_tribal = yes
+            OR = {
+                mpo_permafrost_building_trigger = yes
+                prev.culture = {has_innovation = innovation_barracks}
+            }
+        }
+        add_building = palisades_02
+        prev = {remove_short_term_gold = tribal_building_tier_2_cost}
+    }
 }
-add_building = market_villages_01
-prev = {remove_short_term_gold = tribal_building_tier_1_cost}
-}
-if = {
-limit = {
-prev = {gold > tribal_building_tier_2_cost}
-has_building = market_villages_01
-building_requirement_tribal = yes
-OR = {
-mpo_permafrost_building_trigger = yes
-prev.culture = {has_innovation = innovation_barracks}
-}
-}
-add_building = market_villages_02
-prev = {remove_short_term_gold = tribal_building_tier_2_cost}
-}
+
+
+add_market_villages_building_effect = {
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_1_cost}
+            has_free_building_slot = yes
+            NOT = {
+                has_building = market_villages_01
+                has_building = market_villages_02
+            }
+            building_requirement_tribal = yes
+        }
+        add_building = market_villages_01
+        prev = {remove_short_term_gold = tribal_building_tier_1_cost}
+    }
+    if = {
+        limit = {
+            prev = {gold > tribal_building_tier_2_cost}
+            has_building = market_villages_01
+            building_requirement_tribal = yes
+            OR = {
+                mpo_permafrost_building_trigger = yes
+                prev.culture = {has_innovation = innovation_barracks}
+            }
+        }
+        add_building = market_villages_02
+        prev = {remove_short_term_gold = tribal_building_tier_2_cost}
+    }
 }
 
   # warrior_lodges


### PR DESCRIPTION
## Summary
- restore missing Tribal building effects that broke parsing

## Testing
- `python3 - <<'PY'
path='Original automagic - working - not updated/3071418704/common/scripted_effects/build_scripted_effect.txt'
stack=0
for i,line in enumerate(open(path),1):
    for c in line:
        if c=='{': stack+=1
        elif c=='}': stack-=1
    if stack<0: raise SystemExit(f'negative at {i}')
print('Final',stack)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684f78f74a5c8323823f743331985ae4