### PR TITLE
Fix missing theme in auto_build.0001 event

### DIFF
--- a/Autobuild vassal + self logic/events/auto_build.txt
+++ b/Autobuild vassal + self logic/events/auto_build.txt
@@ -132,12 +132,13 @@ auto_build.0004 = {
 }
 
 auto_build.0001 = {
-	type = character_event
-	title = auto_build.0001.t
-	desc = auto_build.0001.desc
-	weight_multiplier = {
-		base = 1
-	}
+        type = character_event
+        title = auto_build.0001.t
+        desc = auto_build.0001.desc
+        theme = stewardship
+        weight_multiplier = {
+                base = 1
+        }
 	override_background = {
 		reference = terrain
 	}

--- a/Automagic Architect/events/auto_build.txt
+++ b/Automagic Architect/events/auto_build.txt
@@ -3714,12 +3714,13 @@ trigger_event = auto_build.0273 # Hospices
 }
 
 auto_build.0001 = {
-	type = character_event
-	title = auto_build.0001.t
-	desc = auto_build.0001.desc
-	weight_multiplier = {
-		base = 1
-	}
+        type = character_event
+        title = auto_build.0001.t
+        desc = auto_build.0001.desc
+        theme = stewardship
+        weight_multiplier = {
+                base = 1
+        }
 	override_background = {
 		reference = terrain
 	}

--- a/Original automagic - working - not updated/3071418704/events/auto_build.txt
+++ b/Original automagic - working - not updated/3071418704/events/auto_build.txt
@@ -126,12 +126,13 @@ auto_build.0004 = {
 }
 
 auto_build.0001 = {
-	type = character_event
-	title = auto_build.0001.t
-	desc = auto_build.0001.desc
-	weight_multiplier = {
-		base = 1
-	}
+        type = character_event
+        title = auto_build.0001.t
+        desc = auto_build.0001.desc
+        theme = stewardship
+        weight_multiplier = {
+                base = 1
+        }
 	override_background = {
 		reference = terrain
 	}


### PR DESCRIPTION
## Summary
- add `theme = stewardship` to the `auto_build.0001` event

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f7901aed88323b752e47fdd21b083