### PR TITLE
Wrap mod checks around compatibility scripts

### DIFF
--- a/Original automagic needs updating/common/scripted_effects/automagic_mod_compatibility_effects.txt
+++ b/Original automagic needs updating/common/scripted_effects/automagic_mod_compatibility_effects.txt
@@ -2,12 +2,14 @@
 # More Buildings Reboot
 # ----------------------------
 
-aba_building_upgrade_effect_mbrxxx = { 
-    # Economy
+aba_building_upgrade_effect_mbrxxx = {
     if = {
-        limit = { has_building_or_higher = militia_01 }
-        aba_economy_building_upgrade_effect = { BUILDING = militia }
-    }
+        limit = { mod_is_active = "MBRXXX" }
+        # Economy
+        if = {
+            limit = { has_building_or_higher = militia_01 }
+            aba_economy_building_upgrade_effect = { BUILDING = militia }
+        }
     if = {
         limit = { has_building_or_higher = improvement_01 }
         aba_economy_building_upgrade_effect = { BUILDING = improvement }
@@ -176,40 +178,53 @@ aba_building_upgrade_effect_mbrxxx = {
         limit = { has_building_or_higher = shanqiu_01 }
         aba_economy_building_upgrade_effect = { BUILDING = shanqiu }
     }
-    if = {
-        limit = { has_building_or_higher = fayuan_01 }
-        aba_economy_building_upgrade_effect = { BUILDING = fayuan }
+        if = {
+            limit = { has_building_or_higher = fayuan_01 }
+            aba_economy_building_upgrade_effect = { BUILDING = fayuan }
+        }
     }
 }
 
 aba_mbrxxx_building_upgrade_effect = {
-    # Add your upgrade logic for MBRXXX chain here
+    if = {
+        limit = { mod_is_active = "MBRXXX" }
+        # Add your upgrade logic for MBRXXX chain here
+    }
 }
 
 aba_mbrxxx_tribal_building_upgrade_effect = {
-    # Add your tribal building upgrade logic here
+    if = {
+        limit = { mod_is_active = "MBRXXX" }
+        # Add your tribal building upgrade logic here
+    }
 }
 
 # ----------------------------
 # Orient Empires
 # ----------------------------
 
-aba_building_upgrade_effect_oe = { 
+aba_building_upgrade_effect_oe = {
     if = {
-        limit = { has_building_or_higher = tea_plantation_01 }
-        aba_oe_building_upgrade_effect = { BUILDING = tea_plantation }
-    }
-    if = {
-        limit = { has_building_or_higher = sea_spice_plantation_01 }
-        aba_oe_building_upgrade_effect = { BUILDING = sea_spice_plantation }
-    }
-    if = {
-        limit = { has_building_or_higher = silk_plantation_01 }
-        aba_oe_building_upgrade_effect = { BUILDING = silk_plantation }
+        limit = { mod_is_active = "OE" }
+        if = {
+            limit = { has_building_or_higher = tea_plantation_01 }
+            aba_oe_building_upgrade_effect = { BUILDING = tea_plantation }
+        }
+        if = {
+            limit = { has_building_or_higher = sea_spice_plantation_01 }
+            aba_oe_building_upgrade_effect = { BUILDING = sea_spice_plantation }
+        }
+        if = {
+            limit = { has_building_or_higher = silk_plantation_01 }
+            aba_oe_building_upgrade_effect = { BUILDING = silk_plantation }
+        }
     }
 }
 aba_oe_building_upgrade_effect = {
-    # Add Orient Empires specific upgrade logic here
+    if = {
+        limit = { mod_is_active = "OE" }
+        # Add Orient Empires specific upgrade logic here
+    }
 }
 
 # ----------------------------
@@ -218,48 +233,60 @@ aba_oe_building_upgrade_effect = {
 
 aba_building_upgrade_effect_oeex = {
     if = {
-        limit = { has_building_or_higher = qianmutian_01 }
-        aba_oeex_building_upgrade_effect = { BUILDING = qianmutian }
+        limit = { mod_is_active = "OEEX" }
+        if = {
+            limit = { has_building_or_higher = qianmutian_01 }
+            aba_oeex_building_upgrade_effect = { BUILDING = qianmutian }
+        }
+        # Add further blocks for additional OEEX buildings if needed
     }
-    # Add further blocks for additional OEEX buildings if needed
 }
 aba_oeex_building_upgrade_effect = {
-    # Add OEEX upgrade logic here
+    if = {
+        limit = { mod_is_active = "OEEX" }
+        # Add OEEX upgrade logic here
+    }
 }
 aba_oeex_tribal_building_upgrade_effect = {
-    # Add OEEX tribal upgrade logic here
+    if = {
+        limit = { mod_is_active = "OEEX" }
+        # Add OEEX tribal upgrade logic here
+    }
 }
 
 # ----------------------------
 # A Game of Thrones
 # ----------------------------
 
-aba_building_upgrade_effect_agot = { 
-    # Economy
+aba_building_upgrade_effect_agot = {
     if = {
-        limit = { has_building_or_higher = agot_urban_farms_01 }
-        aba_economy_building_upgrade_effect = { BUILDING = agot_urban_farms }
-    }
-    if = {
-        limit = { has_building_or_higher = agot_steppe_farms_01 }
-        aba_economy_building_upgrade_effect = { BUILDING = agot_steppe_farms }
-    }
-    if = {
-        limit = { has_building_or_higher = apiaries_01 }
-        aba_economy_building_upgrade_effect = { BUILDING = apiaries }
-    }
-    # Fortification
-    if = {
-        limit = { has_building_or_higher = building_moat_01 }
-        aba_fortification_building_upgrade_effect = { BUILDING = building_moat }
-    }
-    # Other
-    if = {
-        limit = { has_building_or_higher = agot_slave_camps_01 }
-        aba_default_building_upgrade_effect = { BUILDING = agot_slave_camps }
-    }
-    if = {
-        limit = { has_building_or_higher = godswood_01 }
-        aba_default_building_upgrade_effect = { BUILDING = godswood }
+        limit = { mod_is_active = "AGOT" }
+        # Economy
+        if = {
+            limit = { has_building_or_higher = agot_urban_farms_01 }
+            aba_economy_building_upgrade_effect = { BUILDING = agot_urban_farms }
+        }
+        if = {
+            limit = { has_building_or_higher = agot_steppe_farms_01 }
+            aba_economy_building_upgrade_effect = { BUILDING = agot_steppe_farms }
+        }
+        if = {
+            limit = { has_building_or_higher = apiaries_01 }
+            aba_economy_building_upgrade_effect = { BUILDING = apiaries }
+        }
+        # Fortification
+        if = {
+            limit = { has_building_or_higher = building_moat_01 }
+            aba_fortification_building_upgrade_effect = { BUILDING = building_moat }
+        }
+        # Other
+        if = {
+            limit = { has_building_or_higher = agot_slave_camps_01 }
+            aba_default_building_upgrade_effect = { BUILDING = agot_slave_camps }
+        }
+        if = {
+            limit = { has_building_or_higher = godswood_01 }
+            aba_default_building_upgrade_effect = { BUILDING = godswood }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add mod_is_active checks for More Buildings Reboot
- ensure Orient Empires, OEEX, and AGOT building effects only run when those mods are loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851dba7ce04832384cdf6533cd8158f