### PR TITLE
Add missing custom building triggers

### DIFF
--- a/Original automagic needs updating/common/scripted_triggers/00_custom_building_requirements.txt
+++ b/Original automagic needs updating/common/scripted_triggers/00_custom_building_requirements.txt
@@ -1,0 +1,19 @@
+# Custom building terrain requirement triggers
+
+building_scriptorium_requirement_terrain = {
+    OR = {
+        terrain = plains
+        terrain = farmland
+        terrain = hills
+        terrain = forest
+    }
+}
+
+building_wind_furnace_requirement_terrain = {
+    OR = {
+        terrain = desert
+        terrain = drylands
+        terrain = steppe
+        terrain = desert_mountains
+    }
+}

--- a/Original automagic needs updating/common/scripted_triggers/00_custom_building_requirements.txt
+++ b/Original automagic needs updating/common/scripted_triggers/00_custom_building_requirements.txt
@@ -2,18 +2,18 @@
 
 building_scriptorium_requirement_terrain = {
     OR = {
-        terrain = plains
         terrain = farmland
-        terrain = hills
         terrain = forest
+        terrain = hills
+        terrain = plains
     }
 }
 
 building_wind_furnace_requirement_terrain = {
     OR = {
         terrain = desert
+        terrain = desert_mountains
         terrain = drylands
         terrain = steppe
-        terrain = desert_mountains
     }
 }


### PR DESCRIPTION
## Summary
- add `building_scriptorium_requirement_terrain` and `building_wind_furnace_requirement_terrain` scripted triggers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534f96831483238b9291694499b17a