### PR TITLE
Add magical manager UI files and events

### DIFF
--- a/Original automagic needs updating/common/decisions/clrbnit_magic_aaa_manager_decision.txt
+++ b/Original automagic needs updating/common/decisions/clrbnit_magic_aaa_manager_decision.txt
@@ -1,9 +1,9 @@
-﻿clrbnit_magic_aaa_manager_decision = {
-    picture = { reference = "gfx/interface/magical_castle_bg.dds" }         
-    icon = { reference = "gfx/interface/magical_header_gems.dds" }    
+magical_aaa_manager_decision = {
+    picture = { reference = "gfx/interface/magical_castle_bg.dds" }
+    icon = { reference = "gfx/interface/magical_icon.dds" }
     is_shown = { is_ai = no }
     effect = {
-        trigger_event = magic_build_manager.0001                            
+        trigger_event = magical_manager.0001
     }
     decision_group_type = admin
     ai_check_interval = 0

--- a/Original automagic needs updating/events/magic_build_manager.txt
+++ b/Original automagic needs updating/events/magic_build_manager.txt
@@ -1,0 +1,48 @@
+namespace = magical_manager
+
+magical_manager.0001 = {
+    type = character_event
+    picture = { reference = "GFX_magical_banner" }
+    title = magical_manager.0001.t
+    desc = magical_manager.0001.desc
+    theme = stewardship_domain_focus
+    override_background = { reference = "GFX_magical_throneroom" }
+    left_portrait = root
+
+    immediate = {
+        open_window = magical_manager_window
+    }
+
+    option = {
+        name = magical_manager.0001.enable
+        add_character_flag = magical_enable_build
+    }
+    option = {
+        name = magical_manager.0001.disable
+        remove_character_flag = magical_enable_build
+    }
+    option = {
+        name = magical_manager.0001.about
+        trigger_event = magical_manager.9999
+    }
+    option = {
+        name = magical_manager.0001.exit
+    }
+}
+
+magical_manager.9999 = {
+    type = character_event
+    picture = { reference = "GFX_magical_banner" }
+    title = magical_manager.9999.t
+    desc = magical_manager.9999.desc
+    theme = stewardship_domain_focus
+    override_background = { reference = "GFX_magical_throneroom" }
+
+    option = {
+        name = magical_manager.9999.back
+        trigger_event = magical_manager.0001
+    }
+    option = {
+        name = magical_manager.9999.exit
+    }
+}

--- a/Original automagic needs updating/gfx/magical_manager.gfx
+++ b/Original automagic needs updating/gfx/magical_manager.gfx
@@ -1,0 +1,18 @@
+spriteTypes = {
+    SpriteType = {
+        name = "GFX_magical_castle_bg"
+        texturefile = "gfx/interface/magical_castle_bg.dds"
+    }
+    SpriteType = {
+        name = "GFX_magical_throneroom"
+        texturefile = "gfx/interface/magical_throneroom.dds"
+    }
+    SpriteType = {
+        name = "GFX_magical_banner"
+        texturefile = "gfx/interface/magical_banner.dds"
+    }
+    SpriteType = {
+        name = "GFX_magical_icon"
+        texturefile = "gfx/interface/magical_icon.dds"
+    }
+}

--- a/Original automagic needs updating/gui/magical_manager.gui
+++ b/Original automagic needs updating/gui/magical_manager.gui
@@ -1,0 +1,28 @@
+guiTypes = {
+    windowType = {
+        name = "magical_manager_window"
+        parentanchor = center
+        position = { 0 0 }
+        size = { 960 720 }
+        layer = events
+        moveable = yes
+
+        background = {
+            spriteType = "GFX_magical_throneroom"
+        }
+
+        widget = {
+            name = "header"
+            position = { 0 0 }
+            size = { 960 120 }
+            spriteType = "GFX_magical_banner"
+        }
+
+        buttonType = {
+            name = "confirm_button"
+            position = { 430 660 }
+            quadTextureSprite = "GFX_magical_icon"
+            onclick = "[CloseWindow('magical_manager_window')]"
+        }
+    }
+}

--- a/Original automagic needs updating/localization/english/magical_manager_l_english.yml
+++ b/Original automagic needs updating/localization/english/magical_manager_l_english.yml
@@ -1,0 +1,17 @@
+l_english:
+  magical_aaa_manager_decision: "Automagic Architect"
+  magical_aaa_manager_decision_desc: "Open the Automagic Architect manager to control magical building automation."
+  magical_aaa_manager_decision_tooltip: "Open the Automagic Architect window."
+  magical_aaa_manager_decision_confirm: "Confirm"
+
+  magical_manager.0001.t: "Automagic Architect"
+  magical_manager.0001.desc: "Configure magical construction for your realm."
+  magical_manager.0001.enable: "Enable Magic Build"
+  magical_manager.0001.disable: "Disable Magic Build"
+  magical_manager.0001.about: "About"
+  magical_manager.0001.exit: "Exit"
+
+  magical_manager.9999.t: "Automagic Architect — Credits"
+  magical_manager.9999.desc: "Automagic Architect was created to enhance your magical city building."
+  magical_manager.9999.back: "Back"
+  magical_manager.9999.exit: "Exit"


### PR DESCRIPTION
## Summary
- add GFX sprite definitions for magical manager assets
- create GUI window `magical_manager_window`
- new event script `magical_manager.0001` with about screen
- decision triggers the new magical manager event
- English localization for UI texts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6858c2bd12d88323968db4e24c4de043